### PR TITLE
feat: integrate wstETH bridge addresses

### DIFF
--- a/composables/zksync/deposit/useTransaction.ts
+++ b/composables/zksync/deposit/useTransaction.ts
@@ -1,4 +1,5 @@
 import type { DepositFeeValues } from "@/composables/zksync/deposit/useFee";
+import type { Token } from "@/types";
 import type { BigNumberish } from "ethers";
 import type { L1Signer } from "zksync-ethers";
 
@@ -13,7 +14,7 @@ export default (getL1Signer: () => Promise<L1Signer | undefined>) => {
   const commitTransaction = async (
     transaction: {
       to: string;
-      tokenAddress: string;
+      token: Token;
       amount: BigNumberish;
     },
     fee: DepositFeeValues
@@ -39,11 +40,14 @@ export default (getL1Signer: () => Promise<L1Signer | undefined>) => {
       }
 
       status.value = "waiting-for-signature";
+      const isCustomBridge = isExternalBridgeToken(transaction.token);
+      const bridgeAddress = isCustomBridge ? EXTERNAL_BRIDGES[transaction.token.address] : "";
       const depositResponse = await wallet.deposit({
         to: transaction.to,
-        token: transaction.tokenAddress,
+        token: transaction.token.address,
         amount: transaction.amount,
         l2GasLimit: fee.l2GasLimit,
+        ...(isCustomBridge ? { bridgeAddress } : {}),
         overrides,
       });
 

--- a/data/customBridgeTokens.ts
+++ b/data/customBridgeTokens.ts
@@ -8,14 +8,4 @@ type CustomBridgeToken = {
   symbol: string;
 };
 
-export const customBridgeTokens: CustomBridgeToken[] = [
-  {
-    chainId: 1,
-    l1Address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-    l2Address: "0x703b52F2b28fEbcB60E1372858AF5b18849FE867",
-    bridgeName: "txSync Bridge",
-    bridgeUrlDeposit: "https://portal.txsync.io/bridge/?token=0x703b52F2b28fEbcB60E1372858AF5b18849FE867",
-    bridgeUrlWithdraw: "https://portal.txsync.io/bridge/withdraw/?token=0x703b52F2b28fEbcB60E1372858AF5b18849FE867",
-    symbol: "wstETH",
-  },
-];
+export const customBridgeTokens: CustomBridgeToken[] = [];

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -8,3 +8,18 @@ export const ETH_TOKEN: Token = {
   decimals: 18,
   iconUrl: "/img/eth.svg",
 };
+
+export const WST_ETH_TOKEN: Token = {
+  address: "0x703b52F2b28fEbcB60E1372858AF5b18849FE867",
+  l1Address: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+  symbol: "wstETH",
+  name: "Wrapped liquid staked Ether 2.0",
+  decimals: 18,
+  iconUrl: "https://assets.coingecko.com/coins/images/18834/large/wstETH.png",
+};
+
+// External non-native bridge addresses:
+export const EXTERNAL_BRIDGES = {
+  [WST_ETH_TOKEN.l1Address!]: "0x41527B2d03844dB6b0945f25702cB958b6d55989",
+  [WST_ETH_TOKEN.address]: "0xE1D6A50E7101c8f8db77352897Ee3f1AC53f782B",
+};

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,7 +1,9 @@
 import { BigNumber } from "ethers";
 
+import { EXTERNAL_BRIDGES } from "./constants";
+
 import type { ZkSyncNetwork } from "@/data/networks";
-import type { TokenAmount } from "@/types";
+import type { Token, TokenAmount } from "@/types";
 import type { BigNumberish } from "ethers";
 
 export function isOnlyZeroes(value: string) {
@@ -52,3 +54,7 @@ export async function retry<T>(func: () => Promise<T>, options: RetryOptions = {
     }
   }
 }
+
+export const isExternalBridgeToken = (token: Token) => {
+  return Object.hasOwn(EXTERNAL_BRIDGES, token.address);
+};

--- a/utils/mappers.ts
+++ b/utils/mappers.ts
@@ -40,6 +40,12 @@ export const mapApiToken = (token: Api.Response.Token): Token => {
     };
   }
 
+  // TODO: Update the address on the Block explorer API side
+  // Update the old wstETH address with new one
+  if (token.l1Address === WST_ETH_TOKEN.l1Address) {
+    token.l2Address = WST_ETH_TOKEN.address;
+  }
+
   return {
     l1Address: token.l1Address || undefined,
     address: token.l2Address,

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -606,7 +606,7 @@ const makeTransaction = async () => {
     {
       type: props.type,
       to: transaction.value!.to.address,
-      tokenAddress: transaction.value!.token.address,
+      token: transaction.value!.token,
       amount: transaction.value!.token.amount,
     },
     {


### PR DESCRIPTION
Pass bridge addresses for wstETH token to all relevant transaction requests.
- Update the L2 address in the mapper since the block explorer API is returning the old one - either update on API side or keep the update in the mapper on the front-end