### PR TITLE
feat: shared bridge support

### DIFF
--- a/composables/zksync/deposit/useTransaction.ts
+++ b/composables/zksync/deposit/useTransaction.ts
@@ -44,6 +44,7 @@ export default (getL1Signer: () => Promise<L1Signer | undefined>) => {
         token: transaction.tokenAddress,
         amount: transaction.amount,
         l2GasLimit: fee.l2GasLimit,
+        approveERC20: true,
         overrides,
       });
 

--- a/composables/zksync/deposit/useTransaction.ts
+++ b/composables/zksync/deposit/useTransaction.ts
@@ -44,7 +44,6 @@ export default (getL1Signer: () => Promise<L1Signer | undefined>) => {
         token: transaction.tokenAddress,
         amount: transaction.amount,
         l2GasLimit: fee.l2GasLimit,
-        approveERC20: true,
         overrides,
       });
 

--- a/composables/zksync/useTransaction.ts
+++ b/composables/zksync/useTransaction.ts
@@ -40,7 +40,7 @@ export default (getSigner: () => Promise<Signer | undefined>, getProvider: () =>
       const getRequiredBridgeAddress = async () => {
         if (transaction.tokenAddress === ETH_TOKEN.address) return undefined;
         const bridgeAddresses = await retrieveBridgeAddresses();
-        return bridgeAddresses.erc20L2;
+        return bridgeAddresses.sharedL2;
       };
       const bridgeAddress = transaction.type === "withdrawal" ? await getRequiredBridgeAddress() : undefined;
 

--- a/composables/zksync/useWithdrawalFinalization.ts
+++ b/composables/zksync/useWithdrawalFinalization.ts
@@ -2,7 +2,7 @@ import { useMemoize } from "@vueuse/core";
 import { BigNumber, type BigNumberish } from "ethers";
 import { Wallet } from "zksync-ethers";
 import ZkSyncL1BridgeAbi from "zksync-ethers/abi/IL1Bridge.json";
-import ZkSyncContractAbi from "zksync-ethers/abi/IZkSync.json";
+import ZkSyncContractAbi from "zksync-ethers/abi/IZkSyncStateTransition.json";
 
 import type { Hash } from "@/types";
 
@@ -22,7 +22,6 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
       .getDefaultBridgeAddresses()
       .then((e) => e.erc20L1)
   );
-  const retrieveMainContractAddress = useMemoize(() => providerStore.requestProvider().getMainContractAddress());
 
   const gasLimit = ref<BigNumberish | undefined>();
   const gasPrice = ref<BigNumberish | undefined>();
@@ -70,7 +69,7 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
     finalizeWithdrawalParams.value = await getFinalizationParams();
     if (usingMainContract.value) {
       return {
-        address: (await retrieveMainContractAddress()) as Hash,
+        address: (await retrieveBridgeAddress()) as Hash,
         abi: ZkSyncContractAbi,
         account: onboardStore.account.address!,
         functionName: "finalizeEthWithdrawal",
@@ -145,12 +144,6 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
         onReplaced: (replacement) => {
           transactionHash.value = replacement.transaction.hash;
         },
-      });
-
-      trackEvent("withdrawal-finalized", {
-        token: transactionInfo.value!.token.symbol,
-        amount: transactionInfo.value!.token.amount,
-        to: transactionInfo.value!.to.address,
       });
 
       status.value = "done";

--- a/composables/zksync/useWithdrawalFinalization.ts
+++ b/composables/zksync/useWithdrawalFinalization.ts
@@ -1,7 +1,6 @@
 import { useMemoize } from "@vueuse/core";
 import { BigNumber, type BigNumberish } from "ethers";
 import { Wallet } from "zksync-ethers";
-import ZkSyncL1BridgeAbi from "zksync-ethers/abi/IL1Bridge.json";
 import IL1SharedBridge from "zksync-ethers/abi/IL1SharedBridge.json";
 
 import type { Hash } from "@/types";
@@ -80,8 +79,8 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
       };
     } else {
       return {
-        address: (await retrieveBridgeAddresses()).erc20L1 as Hash,
-        abi: ZkSyncL1BridgeAbi,
+        address: (await retrieveBridgeAddresses()).sharedL1 as Hash,
+        abi: IL1SharedBridge,
         account: onboardStore.account.address!,
         functionName: "finalizeWithdrawal",
         args: Object.values(finalizeWithdrawalParams.value!),

--- a/composables/zksync/useWithdrawalFinalization.ts
+++ b/composables/zksync/useWithdrawalFinalization.ts
@@ -44,7 +44,6 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
   const feeToken = computed(() => {
     return tokens.value?.[ETH_TOKEN.address];
   });
-  const usingMainContract = computed(() => transactionInfo.value.token.address === ETH_TOKEN.address);
 
   const getFinalizationParams = async () => {
     const provider = providerStore.requestProvider();
@@ -69,23 +68,13 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
 
   const getTransactionParams = async () => {
     finalizeWithdrawalParams.value = await getFinalizationParams();
-    if (usingMainContract.value) {
-      return {
-        address: (await retrieveBridgeAddresses()).sharedL1 as Hash,
-        abi: IL1SharedBridge,
-        account: onboardStore.account.address!,
-        functionName: "finalizeWithdrawal",
-        args: Object.values(finalizeWithdrawalParams.value!),
-      };
-    } else {
-      return {
-        address: (await retrieveBridgeAddresses()).sharedL1 as Hash,
-        abi: IL1SharedBridge,
-        account: onboardStore.account.address!,
-        functionName: "finalizeWithdrawal",
-        args: Object.values(finalizeWithdrawalParams.value!),
-      };
-    }
+    return {
+      address: (await retrieveBridgeAddresses()).sharedL1 as Hash,
+      abi: IL1SharedBridge,
+      account: onboardStore.account.address!,
+      functionName: "finalizeWithdrawal",
+      args: Object.values(finalizeWithdrawalParams.value!),
+    };
   };
 
   const {

--- a/data/wagmi.ts
+++ b/data/wagmi.ts
@@ -19,7 +19,7 @@ const useExistingEraChain = (network: ZkSyncNetwork) => {
   const existingNetworks = [zkSync, zkSyncSepoliaTestnet, zkSyncTestnet];
   return existingNetworks.find((existingNetwork) => existingNetwork.id === network.id);
 };
-const createEraChain = (network: ZkSyncNetwork) => {
+const createZKChain = (network: ZkSyncNetwork) => {
   return {
     id: network.id,
     name: network.name,
@@ -29,8 +29,17 @@ const createEraChain = (network: ZkSyncNetwork) => {
       default: { http: [network.rpcUrl] },
       public: { http: [network.rpcUrl] },
     },
+    blockExplorers: network.blockExplorerUrl
+      ? {
+          default: {
+            name: "Explorer",
+            url: network.blockExplorerUrl,
+          },
+        }
+      : undefined,
   };
 };
+
 const getAllChains = () => {
   const chains: Chain[] = [];
   const addUniqueChain = (chain: Chain) => {
@@ -42,7 +51,7 @@ const getAllChains = () => {
     if (network.l1Network) {
       addUniqueChain(network.l1Network);
     }
-    addUniqueChain(useExistingEraChain(network) ?? createEraChain(network));
+    addUniqueChain(useExistingEraChain(network) ?? createZKChain(network));
   }
 
   return chains;

--- a/hyperchains/README.md
+++ b/hyperchains/README.md
@@ -8,23 +8,6 @@ Portal supports custom ZK Stack Hyperchain nodes.
 
 There are a few different ways to configure the application:
 
-### 📁 Configure using ZK Stack configuration files
-<details>
-<summary>If you're using ZK Stack, just link your zksync-era repo directory to configure Portal.</summary>
-
-1. If you haven't already setup your hyperchain yet, follow the [instructions](https://zkstack.io/quickstart)
-2. Make sure to install the dependencies:
-    ```bash
-    npm install
-    ```
-3. 🔄 Pull your hyperchain config files by running:
-    ```bash
-    npm run hyperchain:configure
-    ```
-    This will regenerate `/hyperchains/config.json` file. You can edit this file manually if needed.
-4. 🚀 Now you can start or build the application. See [Development](#development-server) or [Production](#production) section below for more details.
-</details>
-
 ### 🖊️ Configure automatically with form
 <details>
 <summary>Fill out a simple form to configure the application.</summary>
@@ -61,7 +44,9 @@ Array<{
     rpcUrl: string; // L2 RPC URL
     name: string;
     blockExplorerUrl?: string; // L2 Block Explorer URL
+    blockExplorerApi?: string; // L2 Block Explorer API
     hidden?: boolean; // Hidden in the network selector
+    publicL1NetworkId?: number; // If you wish to use Ethereum Mainnet or Ethereum Sepolia Testnet with default configuration. Can be provided instead of `l1Network`
     l1Network?: { // @wagmi `Chain` structure https://wagmi.sh/core/chains#build-your-own
       // minimal required fields shown
       id: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "vite": "^3.0.0",
         "vue-tippy": "^6.0.0",
         "web3-avatar-vue": "^1.0.0",
-        "zksync-ethers": "^5.8.0-beta.5"
+        "zksync-ethers": "^5.9.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
@@ -34517,9 +34517,9 @@
       }
     },
     "node_modules/zksync-ethers": {
-      "version": "5.8.0-beta.5",
-      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.8.0-beta.5.tgz",
-      "integrity": "sha512-saT/3OwLgifqzrBG7OujvUMapzXnshAaLzAZMycUtdV20eLSSVkyLIARVwh1M6hMQIUvX2htV0JN82QRMyM3Ig==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.9.0.tgz",
+      "integrity": "sha512-VnRUesrBcPBmiTYTAp+WreIazK2qCIJEHE7j8BiK+cDApHzjAfIXX+x8SXXJpG1npGJANxiJKnPwA5wjGZtCRg==",
       "dependencies": {
         "ethers": "~5.7.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "vite": "^3.0.0",
         "vue-tippy": "^6.0.0",
         "web3-avatar-vue": "^1.0.0",
-        "zksync-ethers": "^5.5.0"
+        "zksync-ethers": "^5.8.0-beta.5"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
@@ -34517,11 +34517,14 @@
       }
     },
     "node_modules/zksync-ethers": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.5.0.tgz",
-      "integrity": "sha512-sH77qSRSa1iEzy9abK2d5yaKA30QIpztbLUtjRJ34kWujdlVre8Sd0uUzLu+zW56AksU3AHGDl/iMtr/eHhDwg==",
+      "version": "5.8.0-beta.5",
+      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-5.8.0-beta.5.tgz",
+      "integrity": "sha512-saT/3OwLgifqzrBG7OujvUMapzXnshAaLzAZMycUtdV20eLSSVkyLIARVwh1M6hMQIUvX2htV0JN82QRMyM3Ig==",
       "dependencies": {
         "ethers": "~5.7.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "ethers": "~5.7.0"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "vite": "^3.0.0",
     "vue-tippy": "^6.0.0",
     "web3-avatar-vue": "^1.0.0",
-    "zksync-ethers": "^5.5.0"
+    "zksync-ethers": "^5.8.0-beta.5"
   },
   "overrides": {
     "vue": "latest"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "vite": "^3.0.0",
     "vue-tippy": "^6.0.0",
     "web3-avatar-vue": "^1.0.0",
-    "zksync-ethers": "^5.8.0-beta.5"
+    "zksync-ethers": "^5.9.0"
   },
   "overrides": {
     "vue": "latest"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "generate:node:hyperchain": "ts-node --transpile-only scripts/hyperchains/empty-check.ts && cross-env NODE_TYPE=hyperchain npm run generate",
     "generate-meta": "ts-node --transpile-only scripts/updateBridgeMetaTags.ts",
     "hyperchain:create": "ts-node --transpile-only scripts/hyperchains/create.ts",
-    "hyperchain:configure": "ts-node --transpile-only scripts/hyperchains/configure.ts",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "prepare": "husky install",

--- a/pages/send-methods.vue
+++ b/pages/send-methods.vue
@@ -20,9 +20,8 @@
           :to="{ name: 'bridge-withdraw', query: $route.query }"
         />
       </CommonCardWithLineButtons>
-      <CommonCardWithLineButtons>
+      <CommonCardWithLineButtons v-if="eraNetwork.displaySettings?.showPartnerLinks">
         <DestinationItem
-          v-if="eraNetwork.displaySettings?.showPartnerLinks"
           :label="`Bridge to other networks`"
           :description="`Explore ecosystem of third party bridges`"
           :icon="ArrowTopRightOnSquareIcon"

--- a/scripts/hyperchains/common.ts
+++ b/scripts/hyperchains/common.ts
@@ -1,0 +1,9 @@
+import { mainnet, sepolia } from "viem/chains";
+
+import type { ZkSyncNetwork } from "../../data/networks";
+import type { Token } from "../../types";
+
+export type Network = Omit<ZkSyncNetwork & { publicL1NetworkId?: number }, "getTokens">;
+export type Config = { network: Network; tokens: Token[] }[];
+
+export const PUBLIC_L1_CHAINS = [mainnet, sepolia];

--- a/scripts/hyperchains/configure.ts
+++ b/scripts/hyperchains/configure.ts
@@ -10,7 +10,7 @@ import { join as pathJoin, parse as pathParse } from "path";
 
 import { generateNetworkConfig, logUserInfo, promptNetworkReplacement } from "./utils";
 
-import type { Network } from "./utils";
+import type { Network } from "./common";
 import type { Token } from "../../types";
 
 const rootPath = process.env.ZKSYNC_HOME;

--- a/scripts/hyperchains/create.ts
+++ b/scripts/hyperchains/create.ts
@@ -1,9 +1,9 @@
 import { prompt } from "enquirer";
 import slugify from "slugify";
+import { mainnet, Chain } from "viem/chains";
 
+import { PUBLIC_L1_CHAINS, type Network } from "./common";
 import { generateNetworkConfig, logUserInfo, promptNetworkReplacement } from "./utils";
-
-import type { Network } from "./utils";
 
 const promptHyperchainInfo = async (): Promise<Network> => {
   const { id, name }: { id: number; name: string } = await prompt([
@@ -25,95 +25,127 @@ const promptHyperchainInfo = async (): Promise<Network> => {
     key,
     rpcUrl,
     blockExplorerUrl,
+    blockExplorerApi,
     connectedToL1,
-  }: { key: string; rpcUrl: string; blockExplorerUrl: string; connectedToL1: boolean } = await prompt([
-    {
-      message: "Hyperchain key",
-      name: "key",
-      type: "input",
-      required: true,
-      initial: slugify(name, {
-        lower: true,
-        replacement: "-",
-        strict: true,
-      }),
-    },
-    {
-      message: "Hyperchain RPC URL",
-      name: "rpcUrl",
-      type: "input",
-      required: true,
-    },
-    {
-      message: "Hyperchain Block Explorer URL (optional)",
-      name: "blockExplorerUrl",
-      type: "input",
-    },
-    {
-      message: "Is hyperchain connected to L1 network?",
-      name: "connectedToL1",
-      type: "confirm",
-      required: true,
-      initial: true,
-    },
-  ]);
-
-  let l1Network: Network["l1Network"] | undefined;
-  if (connectedToL1) {
-    const {
-      l1NetworkId,
-      l1NetworkName,
-      l1NetworkRpcUrl,
-      l1NetworkBlockExplorerUrl,
-    }: {
-      l1NetworkId: number;
-      l1NetworkName: string;
-      l1NetworkRpcUrl: string;
-      l1NetworkBlockExplorerUrl: string;
-    } = await prompt([
+  }: { key: string; rpcUrl: string; blockExplorerUrl: string; blockExplorerApi: string; connectedToL1: boolean } =
+    await prompt([
       {
-        message: "L1 chain id",
-        name: "l1NetworkId",
-        type: "numeral",
+        message: "Hyperchain key",
+        name: "key",
+        type: "input",
         required: true,
-        float: false,
+        initial: slugify(name, {
+          lower: true,
+          replacement: "-",
+          strict: true,
+        }),
       },
       {
-        message: "Displayed L1 chain name",
-        name: "l1NetworkName",
+        message: "Hyperchain RPC URL",
+        name: "rpcUrl",
         type: "input",
         required: true,
       },
       {
-        message: "L1 chain RPC URL",
-        name: "l1NetworkRpcUrl",
+        message: "Hyperchain Block Explorer URL (optional)",
+        name: "blockExplorerUrl",
         type: "input",
-        required: true,
       },
       {
-        message: "L1 chain Block Explorer URL (optional)",
-        name: "l1NetworkBlockExplorerUrl",
+        message: "Hyperchain Block Explorer API (optional)",
+        name: "blockExplorerApi",
         type: "input",
+      },
+      {
+        message: "Is hyperchain connected to L1 network?",
+        name: "connectedToL1",
+        type: "confirm",
+        required: true,
+        initial: true,
       },
     ]);
 
-    l1Network = {
-      id: l1NetworkId,
-      name: l1NetworkName,
-      nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-      rpcUrls: {
-        default: { http: [l1NetworkRpcUrl] },
-        public: { http: [l1NetworkRpcUrl] },
+  let l1Network: Network["l1Network"] | undefined;
+  let publicL1NetworkId: number | undefined;
+
+  if (connectedToL1) {
+    // Ask select from public L1 chains (should list all options) or `+ Add custom L1 chain`
+    const { selectedOption }: { selectedOption: "add-custom-chain" | Chain } = await prompt({
+      message: "Select L1 chain",
+      name: "selectedOption",
+      type: "select",
+      required: true,
+      choices: [
+        ...PUBLIC_L1_CHAINS.map((chain) => ({
+          name: `${chain.id === mainnet.id ? "Ethereum Mainnet" : "Ethereum " + chain.name}${
+            chain.testnet ? " Testnet" : ""
+          }`,
+          value: chain,
+        })),
+        { name: "+ Add custom L1 chain", value: "add-custom-chain" },
+      ],
+      result(resultName) {
+        return this.choices.find((choice: { name: string }) => choice.name === resultName).value;
       },
-      blockExplorers: l1NetworkBlockExplorerUrl
-        ? {
-            default: {
-              name: l1NetworkName,
-              url: l1NetworkBlockExplorerUrl,
-            },
-          }
-        : undefined,
-    };
+    });
+    if (selectedOption === "add-custom-chain") {
+      const {
+        l1NetworkId,
+        l1NetworkName,
+        l1NetworkRpcUrl,
+        l1NetworkBlockExplorerUrl,
+      }: {
+        l1NetworkId: number;
+        l1NetworkName: string;
+        l1NetworkRpcUrl: string;
+        l1NetworkBlockExplorerUrl: string;
+      } = await prompt([
+        {
+          message: "L1 chain id",
+          name: "l1NetworkId",
+          type: "numeral",
+          required: true,
+          float: false,
+        },
+        {
+          message: "Displayed L1 chain name",
+          name: "l1NetworkName",
+          type: "input",
+          required: true,
+        },
+        {
+          message: "L1 chain RPC URL",
+          name: "l1NetworkRpcUrl",
+          type: "input",
+          required: true,
+        },
+        {
+          message: "L1 chain Block Explorer URL (optional)",
+          name: "l1NetworkBlockExplorerUrl",
+          type: "input",
+        },
+      ]);
+
+      l1Network = {
+        id: l1NetworkId,
+        name: l1NetworkName,
+        nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+        rpcUrls: {
+          default: { http: [l1NetworkRpcUrl] },
+          public: { http: [l1NetworkRpcUrl] },
+        },
+        blockExplorers: l1NetworkBlockExplorerUrl
+          ? {
+              default: {
+                name: l1NetworkName,
+                url: l1NetworkBlockExplorerUrl,
+              },
+            }
+          : undefined,
+      };
+    } else {
+      publicL1NetworkId = selectedOption.id;
+    }
   }
 
   return {
@@ -122,7 +154,9 @@ const promptHyperchainInfo = async (): Promise<Network> => {
     key,
     rpcUrl,
     blockExplorerUrl,
+    blockExplorerApi,
     l1Network,
+    publicL1NetworkId,
   };
 };
 

--- a/scripts/hyperchains/utils.ts
+++ b/scripts/hyperchains/utils.ts
@@ -3,13 +3,8 @@ import { prompt } from "enquirer";
 import { readFileSync, writeFileSync } from "fs";
 import { join as pathJoin } from "path";
 
-import { ETH_TOKEN } from "../../utils/constants";
-
-import type { ZkSyncNetwork } from "../../data/networks";
+import type { Network, Config } from "./common";
 import type { Token } from "../../types";
-
-export type Network = Omit<ZkSyncNetwork, "getTokens">;
-export type Config = { network: Network; tokens: Token[] }[];
 
 export const configPath = pathJoin(__dirname, "../../hyperchains/config.json");
 const getConfig = (): Config => {
@@ -50,10 +45,10 @@ export const promptNetworkReplacement = async (network: Network) => {
 export const generateNetworkConfig = (network: Network, tokens: Token[]) => {
   const config = getConfig();
 
-  // Add ETH token if it's not in the list
+  /* // Add ETH token if it's not in the list
   if (!tokens.some((token: Token) => token.address === ETH_TOKEN.address)) {
     tokens.unshift(ETH_TOKEN);
-  }
+  } */
 
   config.unshift({ network, tokens });
   saveConfig(config);

--- a/store/zksync/transactionStatus.ts
+++ b/store/zksync/transactionStatus.ts
@@ -1,6 +1,6 @@
 import { useStorage } from "@vueuse/core";
 import { decodeEventLog } from "viem";
-import ZkSyncContractInterface from "zksync-ethers/abi/IZkSyncStateTransition.json";
+import IZkSyncHyperchain from "zksync-ethers/abi/IZkSyncHyperchain.json";
 
 import type { FeeEstimationParams } from "@/composables/zksync/useFee";
 import type { TokenAmount, Hash } from "@/types";
@@ -58,7 +58,7 @@ export const useZkSyncTransactionStatusStore = defineStore("zkSyncTransactionSta
     for (const log of transaction.logs) {
       try {
         const { args, eventName } = decodeEventLog({
-          abi: ZkSyncContractInterface,
+          abi: IZkSyncHyperchain,
           data: log.data,
           topics: log.topics,
         });

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -486,7 +486,7 @@ const {
 } = useAllowance(
   computed(() => account.value.address),
   computed(() => selectedToken.value?.address),
-  async () => (await providerStore.requestProvider().getDefaultBridgeAddresses()).erc20L1
+  async () => (await providerStore.requestProvider().getDefaultBridgeAddresses()).sharedL1
 );
 const enoughAllowance = computed(() => {
   if (!allowance.value || !selectedToken.value) {

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -130,14 +130,7 @@
         <CommonButton type="submit" variant="primary" class="mt-block-gap w-full gap-1" @click="buttonContinue()">
           I understand, proceed to bridge
         </CommonButton>
-        <CommonButton
-          as="a"
-          href="https://zksync.dappradar.com/ecosystem?category=defi_bridge"
-          target="_blank"
-          size="sm"
-          class="mx-auto mt-block-gap w-max"
-          @click="disableWalletWarning()"
-        >
+        <CommonButton size="sm" class="mx-auto mt-block-gap w-max" @click="disableWalletWarning()">
           Don't show again
         </CommonButton>
       </template>

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -491,8 +491,7 @@ const withdrawalManualFinalizationRequired = computed(() => {
   if (!transaction.value) return false;
   return (
     props.type === "withdrawal" &&
-    (isCustomNode ||
-      isWithdrawalManualFinalizationRequired(transaction.value.token, eraNetwork.value.l1Network?.id || -1))
+    isWithdrawalManualFinalizationRequired(transaction.value.token, eraNetwork.value.l1Network?.id || -1)
   );
 });
 

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -109,7 +109,7 @@
       </template>
       <template v-else-if="step === 'withdrawal-finalization-warning'">
         <CommonAlert variant="warning" :icon="ExclamationTriangleIcon" class="mb-block-padding-1/2 sm:mb-block-gap">
-          <p>
+          <p v-if="!isCustomNode">
             After a
             <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank"
               >24-hour withdrawal delay</a
@@ -121,6 +121,10 @@
               class="underline underline-offset-2"
               >third-party bridges</a
             >.
+          </p>
+          <p v-else>
+            After transaction is executed on {{ eraNetwork.l1Network?.name }}, you will need to manually claim your
+            funds which requires paying another transaction fee on {{ eraNetwork.l1Network?.name }}.
           </p>
         </CommonAlert>
         <CommonButton
@@ -140,7 +144,7 @@
       </template>
       <template v-else-if="step === 'confirm'">
         <CommonAlert
-          v-if="type === 'withdrawal'"
+          v-if="type === 'withdrawal' && !isCustomNode"
           variant="warning"
           :icon="ExclamationTriangleIcon"
           class="mb-block-padding-1/2 sm:mb-block-gap"

--- a/views/transactions/WithdrawalSubmitted.vue
+++ b/views/transactions/WithdrawalSubmitted.vue
@@ -149,9 +149,7 @@
 <script lang="ts" setup>
 import { ExclamationTriangleIcon } from "@heroicons/vue/24/outline";
 
-import { isWithdrawalManualFinalizationRequired } from "@/composables/zksync/useTransaction";
 import useWithdrawalFinalization from "@/composables/zksync/useWithdrawalFinalization";
-import { isCustomNode } from "@/data/networks";
 
 const props = defineProps({
   transaction: {
@@ -172,11 +170,7 @@ const { connectorName, isCorrectNetworkSet } = storeToRefs(onboardStore);
 
 const isCustomBridgeToken = computed(() => !props.transaction.token.l1Address);
 const withdrawalManualFinalizationRequired = computed(() => {
-  return (
-    !props.transaction.info.completed &&
-    (isCustomNode ||
-      isWithdrawalManualFinalizationRequired(props.transaction.token, eraNetwork.value.l1Network?.id || -1))
-  );
+  return !props.transaction.info.completed;
 });
 const withdrawalFinalizationAvailable = computed(() => {
   return (

--- a/views/transactions/WithdrawalSubmitted.vue
+++ b/views/transactions/WithdrawalSubmitted.vue
@@ -9,6 +9,12 @@
           Your funds will be available on <span class="font-medium">{{ transaction.to.destination.label }}</span> after
           you claim the withdrawal.
         </template>
+        <template v-else-if="isCustomNode">
+          Your funds will be available for claiming after the transaction is processed on
+          <span class="font-medium">{{ eraNetwork.name }}</span> and executed on the
+          <span class="font-medium">{{ eraNetwork.l1Network?.name }}</span
+          >.
+        </template>
         <template v-else>
           Your funds will be available on <span class="font-medium">{{ transaction.to.destination.label }}</span> after
           the <a class="underline underline-offset-2" :href="ZKSYNC_WITHDRAWAL_DELAY" target="_blank">24-hour delay</a>.
@@ -150,6 +156,7 @@
 import { ExclamationTriangleIcon } from "@heroicons/vue/24/outline";
 
 import useWithdrawalFinalization from "@/composables/zksync/useWithdrawalFinalization";
+import { isCustomNode } from "@/data/networks";
 
 const props = defineProps({
   transaction: {


### PR DESCRIPTION
## What
Added v24 support: using the shared bridge instead of era's legacy erc-20 bridge.
## Why
Until now the portal used era's backward compatibility. For other ZK chains to be able to use it, shared bridge compatibility is needed.