### PR TITLE
fix(hyperchain:configure): `envsDirectory` path was outdated

### DIFF
--- a/scripts/hyperchains/configure.ts
+++ b/scripts/hyperchains/configure.ts
@@ -19,7 +19,7 @@ if (!rootPath) {
   process.exit(1);
 }
 
-const envsDirectory = pathJoin(rootPath, "/etc/env");
+const envsDirectory = pathJoin(rootPath, "/etc/env/target");
 const tokensDirectory = pathJoin(rootPath, "/etc/tokens");
 
 const configureHyperchainInfo = async () => {


### PR DESCRIPTION
Target env files are now stored in `etc/env/target`.