### PR TITLE
feat(base-token): automatic fetching

### DIFF
--- a/store/zksync/tokens.ts
+++ b/store/zksync/tokens.ts
@@ -1,5 +1,7 @@
+import * as ethers from "ethers";
 import { $fetch } from "ofetch";
 import { utils } from "zksync-ethers";
+import { IERC20 } from "zksync-ethers/build/utils";
 
 import { customBridgeTokens } from "@/data/customBridgeTokens";
 
@@ -37,24 +39,16 @@ export const useZkSyncTokensStore = defineStore("zkSyncTokens", () => {
 
     if (eraNetwork.value.getTokens && (!baseToken || !ethToken)) {
       configTokens = await eraNetwork.value.getTokens();
-      if (!baseToken) {
-        baseToken = configTokens.find((token) => token.address === L2_BASE_TOKEN_ADDRESS);
-      }
-      if (!ethToken) {
-        ethToken = configTokens.find((token) => token.address === ethL2TokenAddress);
+      if (configTokens) {
+        if (!baseToken) {
+          baseToken = configTokens.find((token) => token.address === L2_BASE_TOKEN_ADDRESS);
+        }
+        if (!ethToken) {
+          ethToken = configTokens.find((token) => token.address === ethL2TokenAddress);
+        }
       }
     }
 
-    if (!baseToken) {
-      baseToken = {
-        address: "0x000000000000000000000000000000000000800A",
-        l1Address: await provider.getBaseTokenContractAddress(),
-        symbol: "BASETOKEN",
-        name: "Base Token",
-        decimals: 18,
-        iconUrl: "/img/eth.svg",
-      };
-    }
     if (!ethToken) {
       ethToken = {
         address: ethL2TokenAddress,
@@ -66,10 +60,38 @@ export const useZkSyncTokensStore = defineStore("zkSyncTokens", () => {
       };
     }
 
+    const btL1Address = await provider.getBaseTokenContractAddress();
+    if (btL1Address !== utils.ETH_ADDRESS) {
+      const l1Rpc = useNetworkStore();
+      const l1Provider = new ethers.providers.JsonRpcProvider(l1Rpc.l1Network?.rpcUrls.default.http[0]);
+      const walletEthers = ethers.Wallet.createRandom();
+      const connectedWallet = walletEthers.connect(l1Provider);
+      const ERC20_L1 = new ethers.Contract(btL1Address, IERC20, connectedWallet);
+      const ERC20_SYMBOL: string = (await ERC20_L1.symbol()) || "BT";
+      const ERC20_DECIMALS = (await ERC20_L1.decimals()) || 18;
+      if (!baseToken) {
+        baseToken = {
+          address: L2_BASE_TOKEN_ADDRESS,
+          l1Address: btL1Address,
+          symbol: ERC20_SYMBOL,
+          name: ERC20_SYMBOL,
+          decimals: ERC20_DECIMALS,
+          iconUrl: "/img/era.svg",
+        };
+      }
+    }
+
+    if (!baseToken) {
+      baseToken = ethToken;
+    }
+
     const tokens = explorerTokens.length ? explorerTokens : configTokens;
-    const nonBaseOrEthExplorerTokens = tokens.filter(
-      (token) => token.address !== L2_BASE_TOKEN_ADDRESS && token.address !== ethL2TokenAddress
-    );
+    let nonBaseOrEthExplorerTokens: Token[] = [];
+    if (tokens) {
+      nonBaseOrEthExplorerTokens = tokens.filter(
+        (token) => token.address !== L2_BASE_TOKEN_ADDRESS && token.address !== ethL2TokenAddress
+      );
+    }
     return [
       baseToken,
       ...(baseToken.address !== ethToken.address ? [ethToken] : []),


### PR DESCRIPTION
## What ❔

Provide a way to track the Base and ETH tokens.

## Why ❔

Maybe the blockExplorerApi is not set and the tokens are not specified in the config file, so if everything fails, ask the RPC for the main tokens.

## How to Reproduce ❔

I've created a hyperchain with basetoken, then `npm run hyperchain:create` and finally: `npm run dev:node:hyperchain `

## Note

I also have a block explorer running but the api is not working, what's the solution for this? or how can i test it out?

If i do:

```sh
curl -X 'GET' \
  'http://block-explorer:3020/tokens?page=1&limit=10&minLiquidity=0' \
  -H 'accept: application/json'
```

I get:

```json
{
  "items": [],
  "meta": {
    "totalItems": 0,
    "itemCount": 0,
    "itemsPerPage": 10,
    "totalPages": 0,
    "currentPage": 1
  },
  "links": {
    "first": "tokens?limit=10&minLiquidity=0",
    "previous": "",
    "next": "",
    "last": ""
  }
}
```

It doesn't even return the base-token address

I've seen that the `mainnet` blockExplorerApi doesn't even have this method. How are extra tokens managed? By just looking at the code, seems that the tokens are manually predefined is that the case?







