### PR TITLE
fix: waiting for tx receipt with retries

### DIFF
--- a/composables/transaction/useAllowance.ts
+++ b/composables/transaction/useAllowance.ts
@@ -84,8 +84,8 @@ export default (
               },
             }),
           {
-            retries: 2,
-            delay: 3_000,
+            retries: 3,
+            delay: 5_000,
           }
         );
         await requestAllowance();

--- a/composables/transaction/useAllowance.ts
+++ b/composables/transaction/useAllowance.ts
@@ -75,13 +75,18 @@ export default (
         });
 
         setAllowanceStatus.value = "sending";
-        const receipt = await retry(() =>
-          getPublicClient().waitForTransactionReceipt({
-            hash: setAllowanceTransactionHash.value!,
-            onReplaced: (replacement) => {
-              setAllowanceTransactionHash.value = replacement.transaction.hash;
-            },
-          })
+        const receipt = await retry(
+          () =>
+            getPublicClient().waitForTransactionReceipt({
+              hash: setAllowanceTransactionHash.value!,
+              onReplaced: (replacement) => {
+                setAllowanceTransactionHash.value = replacement.transaction.hash;
+              },
+            }),
+          {
+            retries: 2,
+            delay: 3_000,
+          }
         );
         await requestAllowance();
 

--- a/composables/transaction/useAllowance.ts
+++ b/composables/transaction/useAllowance.ts
@@ -75,12 +75,14 @@ export default (
         });
 
         setAllowanceStatus.value = "sending";
-        const receipt = await getPublicClient().waitForTransactionReceipt({
-          hash: setAllowanceTransactionHash.value!,
-          onReplaced: (replacement) => {
-            setAllowanceTransactionHash.value = replacement.transaction.hash;
-          },
-        });
+        const receipt = await retry(() =>
+          getPublicClient().waitForTransactionReceipt({
+            hash: setAllowanceTransactionHash.value!,
+            onReplaced: (replacement) => {
+              setAllowanceTransactionHash.value = replacement.transaction.hash;
+            },
+          })
+        );
         await requestAllowance();
 
         setAllowanceStatus.value = "done";

--- a/composables/zksync/useWithdrawalFinalization.ts
+++ b/composables/zksync/useWithdrawalFinalization.ts
@@ -130,12 +130,14 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
       });
 
       status.value = "sending";
-      const receipt = await onboardStore.getPublicClient().waitForTransactionReceipt({
-        hash: transactionHash.value!,
-        onReplaced: (replacement) => {
-          transactionHash.value = replacement.transaction.hash;
-        },
-      });
+      const receipt = await retry(() =>
+        onboardStore.getPublicClient().waitForTransactionReceipt({
+          hash: transactionHash.value!,
+          onReplaced: (replacement) => {
+            transactionHash.value = replacement.transaction.hash;
+          },
+        })
+      );
 
       trackEvent("withdrawal-finalized", {
         token: transactionInfo.value!.token.symbol,

--- a/store/zksync/transactionStatus.ts
+++ b/store/zksync/transactionStatus.ts
@@ -52,9 +52,11 @@ export const useZkSyncTransactionStatusStore = defineStore("zkSyncTransactionSta
 
   const getDepositL2TransactionHash = async (l1TransactionHash: string) => {
     const publicClient = onboardStore.getPublicClient();
-    const transaction = await publicClient.waitForTransactionReceipt({
-      hash: l1TransactionHash as Hash,
-    });
+    const transaction = await retry(() =>
+      publicClient.waitForTransactionReceipt({
+        hash: l1TransactionHash as Hash,
+      })
+    );
     for (const log of transaction.logs) {
       try {
         const { args, eventName } = decodeEventLog({

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -36,17 +36,22 @@ export const silentRouterChange = (location: string, mode: "push" | "replace" = 
 
 interface RetryOptions {
   retries?: number;
+  delay?: number;
 }
 const DEFAULT_RETRY_OPTIONS: RetryOptions = {
   retries: 2,
+  delay: 0,
 };
 export async function retry<T>(func: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-  const { retries } = Object.assign({}, DEFAULT_RETRY_OPTIONS, options);
+  const { retries, delay } = Object.assign({}, DEFAULT_RETRY_OPTIONS, options);
   try {
     return await func();
   } catch (error) {
     if (retries && retries > 0) {
-      return retry(func, { retries: retries - 1 });
+      if (delay) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      return retry(func, { retries: retries - 1, delay });
     } else {
       throw error;
     }


### PR DESCRIPTION
The problem is viem's `waitForTransactionReceipt` throws if RPC API returns tx receipt with a delay. Check out [this issue](https://github.com/wevm/viem/issues/1056). For now to fix it retry logic is added.

