### PR TITLE
fix: disable token select while fee is loading to prevent fee overrides

### DIFF
--- a/components/common/input/TransactionAmount.vue
+++ b/components/common/input/TransactionAmount.vue
@@ -82,6 +82,7 @@
           class="h-max"
           :toggled="selectTokenModalOpened"
           variant="light"
+          :disabled="loading"
           @click="selectTokenModalOpened = true"
         >
           <template #left-icon>

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -50,7 +50,7 @@
           :balances="availableBalances"
           :max-amount="maxAmount"
           :approve-required="!enoughAllowance && (!tokenCustomBridge || !tokenCustomBridge.bridgingDisabled)"
-          :loading="tokensRequestInProgress || balanceInProgress"
+          :loading="tokensRequestInProgress || balanceInProgress || feeLoading"
           class="mb-block-padding-1/2 sm:mb-block-gap"
         >
           <template #dropdown>

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -53,7 +53,7 @@
           :tokens="availableTokens"
           :balances="availableBalances"
           :max-amount="maxAmount"
-          :loading="tokensRequestInProgress || balanceInProgress"
+          :loading="tokensRequestInProgress || balanceInProgress || feeLoading"
         >
           <template v-if="type === 'withdrawal' && account.address" #token-dropdown-bottom>
             <CommonAlert class="sticky bottom-0 mt-6" variant="neutral" :icon="InformationCircleIcon">


### PR DESCRIPTION
Why:
Initially fee is requested for the default token, if another token is selected another fee request is triggered, if the first one takes longer than the second one it overrides the fee with incorrect data for the previous token selected. This happens quite often if default token is ETH as it takes more time to estimate deposit fee for ETH than for ERC20 for example.