### PR TITLE
feat(chore): allow network to have different currency

### DIFF
--- a/data/networks.ts
+++ b/data/networks.ts
@@ -31,6 +31,7 @@ export type ZkSyncNetwork = {
   l1Network?: L1Network;
   blockExplorerUrl?: string;
   blockExplorerApi?: string;
+  nativeCurrency?: { name: string; symbol: string; decimals: number };
   displaySettings?: {
     showPartnerLinks?: boolean;
   };

--- a/data/wagmi.ts
+++ b/data/wagmi.ts
@@ -26,7 +26,7 @@ const formatZkSyncChain = (network: ZkSyncNetwork) => {
     id: network.id,
     name: network.name,
     network: network.key,
-    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    nativeCurrency: network.nativeCurrency || { name: "Ether", symbol: "ETH", decimals: 18 },
     rpcUrls: {
       default: { http: [network.rpcUrl] },
       public: { http: [network.rpcUrl] },


### PR DESCRIPTION
Allows custom networks to have a custom currency that is not ETH