### PR TITLE
feat: introduce fallback transport and batch RPC requests

### DIFF
--- a/data/networks.ts
+++ b/data/networks.ts
@@ -8,7 +8,9 @@ import type { Chain } from "@wagmi/core/chains";
 
 const portalRuntimeConfig = usePortalRuntimeConfig();
 
-// We don't use Ankr token here, since the expectation is that public quota is enough to cover all the requests.
+// We don't use RPC tokens here, since the expectation is that public quota is enough to cover all the requests.
+// We provide several RPC URLs to deal with the case when one of them is down.
+// The expectation is that "more reliable" RPCs are listed first.
 export const l1Networks = {
   mainnet: {
     ...mainnet,
@@ -16,7 +18,7 @@ export const l1Networks = {
     network: "mainnet",
     rpcUrls: {
       default: {
-        http: ["https://rpc.ankr.com/eth/"],
+        http: ["https://rpc.ankr.com/eth/", "https://ethereum-rpc.publicnode.com", "https://cloudflare-eth.com"],
       },
     },
   },
@@ -25,7 +27,11 @@ export const l1Networks = {
     name: "Ethereum Sepolia Testnet",
     rpcUrls: {
       default: {
-        http: ["https://rpc.ankr.com/eth_sepolia/"],
+        http: [
+          "https://rpc.ankr.com/eth_sepolia/",
+          "https://ethereum-sepolia-rpc.publicnode.com",
+          "https://rpc.sepolia.org",
+        ],
       },
     },
   },

--- a/data/wagmi.ts
+++ b/data/wagmi.ts
@@ -59,12 +59,17 @@ const getAllChains = () => {
   return chains;
 };
 
+// Creates a fallback transport for a particular chain.
+const chainTransports = (chain: Chain) => {
+  // We expect all the transports to support batch requests.
+  const httpTransports = chain.rpcUrls.default.http.map((e) => http(e, { batch: true }));
+  return fallback(httpTransports);
+};
+
 const chains = getAllChains();
 export const wagmiConfig = defaultWagmiConfig({
   chains: getAllChains() as any,
-  transports: Object.fromEntries(
-    chains.map((chain) => [chain.id, fallback(chain.rpcUrls.default.http.map((e) => http(e)))])
-  ),
+  transports: Object.fromEntries(chains.map((chain) => [chain.id, chainTransports(chain)])),
   projectId: portalRuntimeConfig.walletConnectProjectId,
   metadata,
   enableCoinbase: false,


### PR DESCRIPTION
- Introduce a few fallback RPCs for the situation where ankr is down
- Enable batch request processing

With that PR portal doesn't run into rate limiting problems when running locally without ankr token (at least on my machine).
