### PR TITLE
fix: use defined L1 network for hyperchain

### DIFF
--- a/data/networks.ts
+++ b/data/networks.ts
@@ -36,7 +36,6 @@ export const l1Networks = {
     },
   },
 } as const;
-
 export type L1Network = Chain;
 
 export type ZkSyncNetwork = {


### PR DESCRIPTION
Updates the network configuration for hyperchains to respect the configured `l1Networks` instead of using default viem chain definitions.