### PR TITLE
fix: send assets broken from ethers v6 migration

### DIFF
--- a/composables/zksync/useTransaction.ts
+++ b/composables/zksync/useTransaction.ts
@@ -62,12 +62,11 @@ export default (getSigner: () => Promise<Signer | undefined>, getProvider: () =>
       });
 
       const txResponse = await signer.sendTransaction(txRequest);
-      const tx = getProvider()._wrapTransaction(txResponse);
 
-      transactionHash.value = tx.hash;
+      transactionHash.value = txResponse.hash;
       status.value = "done";
 
-      return tx;
+      return txResponse;
     } catch (err) {
       error.value = formatError(err as Error);
       status.value = "not-started";

--- a/store/zksync/wallet.ts
+++ b/store/zksync/wallet.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { $fetch } from "ofetch";
-import { L1Signer, L1VoidSigner, BrowserProvider } from "zksync-ethers";
+import { L1Signer, L1VoidSigner, BrowserProvider, Signer } from "zksync-ethers";
 
 import type { Api, TokenAmount } from "@/types";
 import type { BigNumberish } from "ethers";
@@ -23,7 +23,9 @@ export const useZkSyncWalletStore = defineStore("zkSyncWallet", () => {
     }
 
     const web3Provider = new BrowserProvider((await onboardStore.getWallet(eraNetwork.value.id)) as any, "any");
-    const eraL2Signer = web3Provider.getSigner();
+    const rawEthersSigner = await web3Provider.getSigner();
+    const eraL2Signer = Signer.from(rawEthersSigner, Number(eraNetwork.value.id), providerStore.requestProvider());
+
     return eraL2Signer;
   });
   const { execute: getL1Signer, reset: resetL1Signer } = usePromise(async () => {


### PR DESCRIPTION
Following changes fix issue initially detected here: https://github.com/zkSync-Community-Hub/zksync-developers/discussions/895


Era portal changes from https://github.com/matter-labs/dapp-portal/pull/208 haven't been deployed to production yet so issue has not been experienced for era users yet. 