### PR TITLE
fix: check token addresses with uppercase

### DIFF
--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -38,7 +38,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
   });
 
   const feeToken = computed(() => {
-    return tokens.value.find((e) => e.address === utils.ETH_ADDRESS);
+    return tokens.value.find((e) => e.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase());
   });
   const enoughBalanceToCoverFee = computed(() => {
     if (!feeToken.value || !balances.value || inProgress.value) {

--- a/store/zksync/ethereumBalance.ts
+++ b/store/zksync/ethereumBalance.ts
@@ -41,8 +41,8 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
           amount: "0",
         })),
     ].sort((a, b) => {
-      if (a.address === utils.ETH_ADDRESS) return -1; // Always bring ETH to the beginning
-      if (b.address === utils.ETH_ADDRESS) return 1; // Keep ETH at the beginning if comparing with any other token
+      if (a.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase()) return -1; // Always bring ETH to the beginning
+      if (b.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase()) return 1; // Keep ETH at the beginning if comparing with any other token
       return 0; // Keep other tokens' order unchanged
     });
   };
@@ -56,7 +56,7 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
         const amount = await getBalance(wagmiConfig, {
           address: account.value.address!,
           chainId: l1Network.value!.id,
-          token: token.address === utils.ETH_ADDRESS ? undefined : (token.address! as Hash),
+          token: token.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase() ? undefined : (token.address! as Hash),
         });
         return {
           ...token,

--- a/store/zksync/tokens.ts
+++ b/store/zksync/tokens.ts
@@ -31,17 +31,17 @@ export const useZkSyncTokensStore = defineStore("zkSyncTokens", () => {
         $fetch(`${eraNetwork.value.blockExplorerApi}/tokens?minLiquidity=0&limit=100&page=3`),
       ]);
       explorerTokens = responses.map((response) => response.items.map(mapApiToken)).flat();
-      baseToken = explorerTokens.find((token) => token.address === L2_BASE_TOKEN_ADDRESS);
-      ethToken = explorerTokens.find((token) => token.address === ethL2TokenAddress);
+      baseToken = explorerTokens.find((token) => token.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase());
+      ethToken = explorerTokens.find((token) => token.address.toUpperCase() === ethL2TokenAddress.toUpperCase());
     }
 
     if (eraNetwork.value.getTokens && (!baseToken || !ethToken)) {
       configTokens = await eraNetwork.value.getTokens();
       if (!baseToken) {
-        baseToken = configTokens.find((token) => token.address === L2_BASE_TOKEN_ADDRESS);
+        baseToken = configTokens.find((token) => token.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase());
       }
       if (!ethToken) {
-        ethToken = configTokens.find((token) => token.address === ethL2TokenAddress);
+        ethToken = configTokens.find((token) => token.address.toUpperCase() === ethL2TokenAddress.toUpperCase());
       }
     }
 
@@ -72,11 +72,11 @@ export const useZkSyncTokensStore = defineStore("zkSyncTokens", () => {
     );
     return [
       baseToken,
-      ...(baseToken.address !== ethToken.address ? [ethToken] : []),
+      ...(baseToken.address.toUpperCase() !== ethToken.address.toUpperCase() ? [ethToken] : []),
       ...nonBaseOrEthExplorerTokens,
     ].map((token) => ({
       ...token,
-      isETH: token.address === ethL2TokenAddress,
+      isETH: token.address.toUpperCase() === ethL2TokenAddress.toUpperCase(),
     }));
   });
 
@@ -101,7 +101,7 @@ export const useZkSyncTokensStore = defineStore("zkSyncTokens", () => {
   });
   const baseToken = computed<Token | undefined>(() => {
     if (!tokensRaw.value) return undefined;
-    return tokensRaw.value.find((token) => token.address === L2_BASE_TOKEN_ADDRESS);
+    return tokensRaw.value.find((token) => token.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase());
   });
   const ethToken = computed<Token | undefined>(() => {
     if (!tokensRaw.value) return undefined;

--- a/store/zksync/wallet.ts
+++ b/store/zksync/wallet.ts
@@ -129,8 +129,8 @@ export const useZkSyncWalletStore = defineStore("zkSyncWallet", () => {
         return { ...token, amount };
       })
       .sort((a, b) => {
-        if (a.address === L2_BASE_TOKEN_ADDRESS) return -1; // Always bring ETH to the beginning
-        if (b.address === L2_BASE_TOKEN_ADDRESS) return 1; // Keep ETH at the beginning if comparing with any other token
+        if (a.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase()) return -1; // Always bring ETH to the beginning
+        if (b.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase()) return 1; // Keep ETH at the beginning if comparing with any other token
         return 0; // Keep other tokens' order unchanged
       });
     const knownTokenAddresses = new Set(knownTokens.map((token) => token.address));

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -245,7 +245,7 @@
                   <CommonAlert variant="error" :icon="ExclamationTriangleIcon">
                     <p>
                       {{
-                        selectedToken?.address === L2_BASE_TOKEN_ADDRESS
+                        selectedToken?.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase()
                           ? "The fee has changed since the last estimation. "
                           : ""
                       }}Insufficient <span class="font-medium">{{ selectedToken?.symbol }}</span> balance to pay for
@@ -351,7 +351,10 @@ const routeTokenAddress = computed(() => {
   return checksumAddress(route.query.token);
 });
 const defaultToken = computed(
-  () => availableTokens.value.find((e) => e.address === L2_BASE_TOKEN_ADDRESS) ?? availableTokens.value[0] ?? undefined
+  () =>
+    availableTokens.value.find((e) => e.address.toUpperCase() === L2_BASE_TOKEN_ADDRESS.toUpperCase()) ??
+    availableTokens.value[0] ??
+    undefined
 );
 const selectedTokenAddress = ref<string | undefined>(routeTokenAddress.value ?? defaultToken.value?.address);
 const selectedToken = computed<Token | undefined>(() => {


### PR DESCRIPTION
Add the `.toUpperCase()` to the address checks where they might be relevant.

The issue was caused by comparing the `0x000000000000000000000000000000000000800A` address to `0x000000000000000000000000000000000000800a` and it would return as two different strings, thus adding the ETH token twice to the array.

This PR fixes https://github.com/matter-labs/dapp-portal/issues/222