### PR TITLE
fix: address withdrawal finalization changes from v26

### DIFF
--- a/composables/zksync/useWithdrawalFinalization.ts
+++ b/composables/zksync/useWithdrawalFinalization.ts
@@ -1,10 +1,12 @@
 import { useMemoize } from "@vueuse/core";
 import { Wallet } from "zksync-ethers";
-import IL1SharedBridge from "zksync-ethers/abi/IL1SharedBridge.json";
+import IL1Nullifier from "zksync-ethers/abi/IL1Nullifier.json";
+import { IL1AssetRouter__factory as IL1AssetRouterFactory } from "zksync-ethers/build/typechain";
 
 import { useSentryLogger } from "../useSentryLogger";
 
 import type { Hash } from "@/types";
+import type { FinalizeWithdrawalParams } from "zksync-ethers/build/types";
 
 export default (transactionInfo: ComputedRef<TransactionInfo>) => {
   const status = ref<"not-started" | "processing" | "waiting-for-signature" | "sending" | "done">("not-started");
@@ -12,32 +14,21 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
   const transactionHash = ref<Hash | undefined>();
   const onboardStore = useOnboardStore();
   const providerStore = useZkSyncProviderStore();
+  const walletStore = useZkSyncWalletStore();
   const tokensStore = useZkSyncTokensStore();
   const { isCorrectNetworkSet } = storeToRefs(onboardStore);
   const { ethToken } = storeToRefs(tokensStore);
   const { captureException } = useSentryLogger();
 
   const retrieveBridgeAddresses = useMemoize(() => providerStore.requestProvider().getDefaultBridgeAddresses());
-
-  const retrieveChainId = useMemoize(() =>
-    providerStore
-      .requestProvider()
-      .getNetwork()
-      .then((network) => network.chainId)
-  );
+  const retrieveL1NullifierAddress = useMemoize(async () => {
+  const providerL1 = walletStore.getL1VoidSigner();
+    return IL1AssetRouterFactory.connect((await retrieveBridgeAddresses()).sharedL1, providerL1).L1_NULLIFIER();
+  });
 
   const gasLimit = ref<bigint | undefined>();
   const gasPrice = ref<bigint | undefined>();
-  const finalizeWithdrawalParams = ref<
-    | {
-        l1BatchNumber: unknown;
-        l2MessageIndex: unknown;
-        l2TxNumberInBlock: unknown;
-        message: unknown;
-        proof: unknown;
-      }
-    | undefined
-  >();
+  const finalizeWithdrawalParams = ref<FinalizeWithdrawalParams | undefined>();
 
   const totalFee = computed(() => {
     if (!gasLimit.value || !gasPrice.value) return undefined;
@@ -55,24 +46,14 @@ export default (transactionInfo: ComputedRef<TransactionInfo>) => {
       "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110",
       provider
     );
-    const { l1BatchNumber, l2MessageIndex, l2TxNumberInBlock, message, proof } = await wallet.finalizeWithdrawalParams(
-      transactionInfo.value.transactionHash
-    );
-    return {
-      chainId: await retrieveChainId(),
-      l1BatchNumber,
-      l2MessageIndex,
-      l2TxNumberInBlock,
-      message,
-      proof,
-    };
+    return await wallet.getFinalizeWithdrawalParams(transactionInfo.value.transactionHash);
   };
 
   const getTransactionParams = async () => {
     finalizeWithdrawalParams.value = await getFinalizationParams();
     return {
-      address: (await retrieveBridgeAddresses()).sharedL1 as Hash,
-      abi: IL1SharedBridge,
+      address: (await retrieveL1NullifierAddress()) as Hash,
+      abi: IL1Nullifier,
       account: onboardStore.account.address!,
       functionName: "finalizeWithdrawal",
       args: Object.values(finalizeWithdrawalParams.value!),


### PR DESCRIPTION
## Description

- Addresses changes from v26 withdrawal finalization based on https://github.com/matter-labs/dapp-portal/pull/227/files

## Evidence

Tx: https://era.zksync.network/tx/0xd677ed3881b1c95769b732306340b2ecf8329393f226c3db4273a75ccb752345
Tx: https://etherscan.io/tx/0x1830e786522e8f2d24c18767e483dccc364aa4857d6cd436a2654835ede940dd

<img width="772" alt="Screenshot 2025-05-17 at 3 46 56 PM" src="https://github.com/user-attachments/assets/ca0ee053-0f19-44a9-9d5e-cf9819ce24c9" />
