### PR TITLE
fix: withdrawal estimation error

### DIFF
--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -406,7 +406,12 @@ const {
   enoughBalanceToCoverFee,
   estimateFee,
   resetFee,
-} = useFee(providerStore.requestProvider, tokens, balance);
+} = useFee(
+  computed(() => account.value.address),
+  providerStore.requestProvider,
+  tokens,
+  balance
+);
 
 const queryAddress = useRouteQuery<string | undefined>("address", undefined, {
   transform: String,


### PR DESCRIPTION
Currently if you go to withdrawal page you might see an error if:
- Token balance is 0. Fixed to not do an estimation in such case.
- Cached token balance isn't equal to your actual balance. Fixed to fetch latest actual balance before doing an estimation.