### PR TITLE
Allow block explorer url using query params for network selection

### DIFF
--- a/components/header/AccountDropdown.vue
+++ b/components/header/AccountDropdown.vue
@@ -23,7 +23,7 @@
             no-chevron
             :active="active"
             as="a"
-            :href="`${selectedNetwork.blockExplorerUrl}/address/${account.address!}`"
+            :href="buildExplorerUrl(selectedNetwork.blockExplorerUrl, account.address)"
             target="_blank"
             class="options-item"
           >

--- a/components/header/MobileAccountNavigation.vue
+++ b/components/header/MobileAccountNavigation.vue
@@ -16,7 +16,7 @@
           <DestinationItem
             label="View on Explorer"
             as="a"
-            :href="`${selectedNetwork.blockExplorerUrl}/address/${account.address}`"
+            :href="buildExplorerUrl(selectedNetwork.blockExplorerUrl, account.address)"
             target="_blank"
             :icon="ArrowTopRightOnSquareIcon"
             size="sm"

--- a/components/transaction/TransactionHashButton.vue
+++ b/components/transaction/TransactionHashButton.vue
@@ -34,7 +34,7 @@
         size="xs"
         variant="light"
         as="a"
-        :href="`${explorerUrl}/tx/${transactionHash}`"
+        :href="buildExplorerUrl(explorerUrl, transactionHash)"
         target="_blank"
         class="transaction-hash-button"
       >

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -168,3 +168,17 @@ export function getTokensWithCustomBridgeTokens(
 
   return sortedTokens;
 }
+
+export function buildExplorerUrl(baseUrl: string, value?: string): string | undefined {
+  if (!value) return;
+
+  const [urlPart, queryPart] = baseUrl.split("?");
+  const base = urlPart.replace(/\/$/, "");
+
+  const type = value.length === 66 ? "tx" : value.length === 42 ? "address" : undefined;
+
+  if (!type) return;
+
+  const url = `${base}/${type}/${value}`;
+  return queryPart ? `${url}?${queryPart}` : url;
+}

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -257,9 +257,7 @@
                 >
                   <a
                     v-if="l1BlockExplorerUrl && allowanceTransactionHash"
-                    :href="`${l1BlockExplorerUrl.split('?')[0]}/tx/${allowanceTransactionHash}?${
-                      l1BlockExplorerUrl.split('?')[1]
-                    }`"
+                    :href="buildExplorerUrl(l1BlockExplorerUrl, allowanceTransactionHash)"
                     target="_blank"
                     class="inline-flex items-center gap-1 underline underline-offset-2"
                   >

--- a/views/transactions/Deposit.vue
+++ b/views/transactions/Deposit.vue
@@ -233,7 +233,7 @@
                 <template v-for="allowanceReceipt in setAllowanceReceipts" :key="allowanceReceipt.transactionHash">
                   <a
                     v-if="l1BlockExplorerUrl"
-                    :href="`${l1BlockExplorerUrl}/tx/${allowanceReceipt.transactionHash}`"
+                    :href="buildExplorerUrl(l1BlockExplorerUrl, allowanceReceipt.transactionHash)"
                     target="_blank"
                     class="inline-flex items-center gap-1 underline underline-offset-2"
                   >
@@ -257,7 +257,9 @@
                 >
                   <a
                     v-if="l1BlockExplorerUrl && allowanceTransactionHash"
-                    :href="`${l1BlockExplorerUrl}/tx/${allowanceTransactionHash}`"
+                    :href="`${l1BlockExplorerUrl.split('?')[0]}/tx/${allowanceTransactionHash}?${
+                      l1BlockExplorerUrl.split('?')[1]
+                    }`"
                     target="_blank"
                     class="inline-flex items-center gap-1 underline underline-offset-2"
                   >

--- a/views/transactions/TransferSubmitted.vue
+++ b/views/transactions/TransferSubmitted.vue
@@ -8,7 +8,7 @@
         Your funds will be available at the
         <a
           v-if="blockExplorerUrl"
-          :href="`${blockExplorerUrl}/address/${transaction!.to.address}`"
+          :href="buildExplorerUrl(blockExplorerUrl, transaction!.to.address)"
           target="_blank"
           class="font-medium underline underline-offset-2"
           >destination address</a


### PR DESCRIPTION
Use an utility function to preserve the block explorer query params (e.g: ?network=) from the block explorer url