### PR TITLE
fix: prevent MsgValueTooLow errors in deposit transactions due to gas price timing

### DIFF
--- a/composables/zksync/deposit/useTransaction.ts
+++ b/composables/zksync/deposit/useTransaction.ts
@@ -55,10 +55,17 @@ export default (getL1Signer: () => Promise<L1Signer | undefined>) => {
       l2Value
     );
 
-    const baseCost = await l1Signer.getBaseCost({
-      gasLimit: l2GasLimit,
-      gasPerPubdataByte: gasPerPubdata,
-    });
+    // Use baseCost from fee if available to prevent gas price timing issues
+    // Otherwise recalculate (fallback for backward compatibility)
+    let baseCost: bigint;
+    if (fee.baseCost) {
+      baseCost = fee.baseCost;
+    } else {
+      baseCost = await l1Signer.getBaseCost({
+        gasLimit: l2GasLimit,
+        gasPerPubdataByte: gasPerPubdata,
+      });
+    }
 
     const overrides = {
       gasPrice: fee.gasPrice,


### PR DESCRIPTION
Cache baseCost during fee estimation instead of recalculating at transaction submission to eliminate timing race conditions between gas price changes and transaction execution.