### PR TITLE
fix: show failure state for reverted L1 deposit transactions

### DIFF
--- a/views/transactions/DepositSubmitted.vue
+++ b/views/transactions/DepositSubmitted.vue
@@ -1,14 +1,21 @@
 <template>
   <div>
     <h1 class="h1 mt-block-gap-1/2 text-center">
-      {{ transaction.info.completed ? "Transaction completed" : "Transaction submitted" }}
+      <template v-if="transaction.info.failed">Transaction failed</template>
+      <template v-else>{{ transaction.info.completed ? "Transaction completed" : "Transaction submitted" }}</template>
     </h1>
-    <CommonHeightTransition :opened="!transaction.info.completed">
+    <CommonHeightTransition :opened="!transaction.info.completed || transaction.info.failed">
       <p class="mb-4 text-center">
-        Your funds will be available after the transaction is committed on
-        <span class="font-medium">{{ transaction.from.destination.label }}</span> and then processed on
-        <span class="font-medium">{{ transaction.to.destination.label }}</span
-        >. You are free to close this page.
+        <template v-if="transaction.info.failed">
+          The deposit transaction failed on <span class="font-medium">{{ transaction.from.destination.label }}</span>
+          . Your funds remain in your wallet and were not bridged.
+        </template>
+        <template v-else>
+          Your funds will be available after the transaction is committed on
+          <span class="font-medium">{{ transaction.from.destination.label }}</span> and then processed on
+          <span class="font-medium">{{ transaction.to.destination.label }}</span
+          >. You are free to close this page.
+        </template>
       </p>
     </CommonHeightTransition>
     <TransactionProgress


### PR DESCRIPTION
Changes:
- Modified getDepositStatus() to check L1 transaction status before attempting to extract L2 transaction hash
- Set failed=true and completed=true when L1 transaction is reverted
- Updated DepositSubmitted.vue to show clear failure messaging
- Improved efficiency by eliminating duplicate L1 receipt API calls
- Enhanced error handling to distinguish transaction vs network errors
- Avoided parameter mutation for better code maintainability

Fixes https://github.com/matter-labs/dapp-portal/issues/262

<img width="833" height="528" alt="image" src="https://github.com/user-attachments/assets/b8d0b05d-7ff3-45e5-b682-b49ff4abebf1" />
