### PR TITLE
fix: increase gas buffer to 120% to prevent MsgValueTooLow errors

### DIFF
--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -72,7 +72,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
     };
   };
   const getGasPrice = async () => {
-    return (BigInt(await retry(() => getPublicClient().getGasPrice())) * 110n) / 100n;
+    return (BigInt(await retry(() => getPublicClient().getGasPrice())) * 120n) / 100n;
   };
   const {
     inProgress,

--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -72,7 +72,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
     };
   };
   const getGasPrice = async () => {
-    return (BigInt(await retry(() => getPublicClient().getGasPrice())) * 120n) / 100n;
+    return (BigInt(await retry(() => getPublicClient().getGasPrice())) * 130n) / 100n;
   };
   const {
     inProgress,

--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -116,6 +116,15 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
       /* It can be either maxFeePerGas or gasPrice */
       if (fee.value && !fee.value?.maxFeePerGas) {
         fee.value.gasPrice = await getGasPrice();
+      } else if (fee.value?.maxFeePerGas) {
+        // Apply 130% buffer to EIP-1559 parameters
+        fee.value.maxFeePerGas = (fee.value.maxFeePerGas * 130n) / 100n;
+        if (fee.value.maxPriorityFeePerGas) {
+          fee.value.maxPriorityFeePerGas = (fee.value.maxPriorityFeePerGas * 130n) / 100n;
+        }
+        if (fee.value.l1GasLimit) {
+          fee.value.l1GasLimit = (fee.value.l1GasLimit * 130n) / 100n;
+        }
       }
     },
     { cache: false }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "vue-tippy": "^6.0.0",
         "web3-avatar-vue": "^1.0.0",
         "zksync-easy-onramp": "3.2.1",
-        "zksync-ethers": "^6.18.0"
+        "zksync-ethers": "^6.20.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
@@ -35048,10 +35048,9 @@
       }
     },
     "node_modules/zksync-ethers": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-6.18.0.tgz",
-      "integrity": "sha512-ScBZNlgYGppmq775mK36d44G5zS+PM4inzwlcKD1vFM2AleV9VvZmCOr7CSZGWTLofNraE4l7bhpwj8WAM/Osw==",
-      "license": "MIT",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/zksync-ethers/-/zksync-ethers-6.20.0.tgz",
+      "integrity": "sha512-xmWGjC5+LflXggK3hUGwQV6jeURAMLr+cxIWTos25cxv/gsEcXiJecgvYdinwmVfxOSNShDwBVA0lJOO0DKgqA==",
       "engines": {
         "node": ">=18.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "vue-tippy": "^6.0.0",
     "web3-avatar-vue": "^1.0.0",
     "zksync-easy-onramp": "3.2.1",
-    "zksync-ethers": "^6.18.0"
+    "zksync-ethers": "^6.20.0"
   },
   "overrides": {
     "vue": "latest"


### PR DESCRIPTION
- increase gas buffer to 120% to prevent MsgValueTooLow errors
- update package.json and package-lock.json to latest zksync-ethers (6.20.0)