### PR TITLE
fix: add 130% buffer to baseCost to prevent deposit failures

### DIFF
--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -126,6 +126,11 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
           fee.value.l1GasLimit = (fee.value.l1GasLimit * 130n) / 100n;
         }
       }
+      
+      // Apply 130% buffer to baseCost to prevent MsgValueTooLow errors
+      if (fee.value?.baseCost) {
+        fee.value.baseCost = (fee.value.baseCost * 130n) / 100n;
+      }
     },
     { cache: false }
   );


### PR DESCRIPTION
Applies buffer to L2 execution cost component that was missed in previous gas buffer fix, preventing MsgValueTooLow errors from baseCost fluctuations.