### PR TITLE
fix: implement proper Gateway withdrawal status checking

### DIFF
--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -126,7 +126,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
           fee.value.l1GasLimit = (fee.value.l1GasLimit * 130n) / 100n;
         }
       }
-      
+
       // Apply 130% buffer to baseCost to prevent MsgValueTooLow errors
       if (fee.value?.baseCost) {
         fee.value.baseCost = (fee.value.baseCost * 130n) / 100n;

--- a/store/zksync/provider.ts
+++ b/store/zksync/provider.ts
@@ -1,8 +1,22 @@
 import { Provider } from "zksync-ethers";
 
+import { chainList } from "@/data/networks";
+
 export const useZkSyncProviderStore = defineStore("zkSyncProvider", () => {
   const { selectedNetwork } = storeToRefs(useNetworkStore());
   let provider: Provider | undefined;
+  let gatewayProvider: Provider | undefined;
+
+  // Automatically select the correct Gateway network based on current network
+  const selectedGatewayNetwork = computed(() => {
+    const currentNetwork = selectedNetwork.value;
+    const currentL1Network = currentNetwork.l1Network;
+
+    // Find the Gateway network that matches the current L1 network
+    return chainList.find(
+      (network) => network.key.includes("gateway") && network.l1Network?.id === currentL1Network?.id
+    );
+  });
 
   const requestProvider = () => {
     if (!provider) {
@@ -11,11 +25,21 @@ export const useZkSyncProviderStore = defineStore("zkSyncProvider", () => {
     return provider;
   };
 
+  const requestGatewayProvider = () => {
+    if (!gatewayProvider) {
+      if (!selectedGatewayNetwork.value) {
+        throw new Error("Gateway network configuration not found");
+      }
+      gatewayProvider = new Provider(selectedGatewayNetwork.value.rpcUrl);
+    }
+    return gatewayProvider;
+  };
+
   return {
     eraNetwork: selectedNetwork,
-
+    selectedGatewayNetwork,
     requestProvider,
-
+    requestGatewayProvider,
     blockExplorerUrl: computed(() => selectedNetwork.value.blockExplorerUrl),
   };
 });

--- a/store/zksync/withdrawals.ts
+++ b/store/zksync/withdrawals.ts
@@ -13,6 +13,30 @@ export const useZkSyncWithdrawalsStore = defineStore("zkSyncWithdrawals", () => 
   const { userTransactions } = storeToRefs(transactionStatusStore);
   const { destinations } = storeToRefs(useDestinationsStore());
 
+  // Check if settlement layer has executed on Gateway before marking as ready for finalization
+  const checkSettlementLayerExecution = async (ethExecuteTxHash: string | null): Promise<boolean> => {
+    if (!ethExecuteTxHash) return false;
+
+    try {
+      // Use Gateway provider to check Gateway transaction status
+      const gatewayProvider = providerStore.requestGatewayProvider();
+
+      // Check transaction details like zkSync chains do
+      const gatewayTransactionDetails = await gatewayProvider.getTransactionDetails(ethExecuteTxHash);
+
+      if (!gatewayTransactionDetails) {
+        return false;
+      }
+
+      // Check if the withdrawal is actually ready (similar to zkSync chain logic)
+      const isReady = gatewayTransactionDetails.status === "verified";
+
+      return isReady;
+    } catch (error) {
+      return false;
+    }
+  };
+
   const updateWithdrawals = async () => {
     if (!isConnected.value) throw new Error("Account is not available");
     if (!eraNetwork.value.blockExplorerApi)
@@ -33,7 +57,9 @@ export const useZkSyncWithdrawalsStore = defineStore("zkSyncWithdrawals", () => 
         providerStore.requestProvider().getTransactionDetails(withdrawal.transactionHash!)
       );
 
-      const withdrawalFinalizationAvailable = !!transactionDetails.ethExecuteTxHash;
+      const withdrawalFinalizationAvailable = await checkSettlementLayerExecution(
+        transactionDetails.ethExecuteTxHash || null
+      );
       const isFinalized = withdrawalFinalizationAvailable
         ? await useZkSyncWalletStore()
             .getL1VoidSigner(true)


### PR DESCRIPTION
- Add checkSettlementLayerExecution function to verify Gateway transaction status
- Use Gateway RPC provider instead of Ethereum L1 for ethExecuteTxHash validation
- Dynamically select Gateway network based on selected ZKsync Era network
- Fix withdrawalFinalizationAvailable logic to check actual Gateway execution status
- Resolve "Log proof not found" error by ensuring proper finalization status

This ensures Gateway withdrawals are only marked
as ready for claiming when they have actually been executed on the settlement layer, rather than
prematurely based on the presence of
ethExecuteTxHash.