### PR TITLE
fix: update withdrawal status tracking

### DIFF
--- a/hyperchains/example.config.json
+++ b/hyperchains/example.config.json
@@ -5,6 +5,11 @@
       "key": "my-hyperchain",
       "name": "My new hyperchain",
       "rpcUrl": "http://127.0.0.1:3050",
+      "blockExplorerUrl": "http://127.0.0.1:3010",
+      "blockExplorerApi": "http://127.0.0.1:3002",
+      "displaySettings": {
+        "isTestnet": true
+      },
       "l1Network": {
         "id": 9,
         "name": "Localhost",

--- a/store/zksync/transactionStatus.ts
+++ b/store/zksync/transactionStatus.ts
@@ -22,7 +22,7 @@ export type TransactionInfo = {
 };
 
 export const ESTIMATED_DEPOSIT_DELAY = 15 * 60 * 1000; // 15 minutes
-export const WITHDRAWAL_DELAY = 5 * 60 * 60 * 1000; // 5 hours
+export const WITHDRAWAL_DELAY = 6 * 60 * 60 * 1000; // 6 hours
 
 export const useZkSyncTransactionStatusStore = defineStore("zkSyncTransactionStatus", () => {
   const onboardStore = useOnboardStore();

--- a/store/zksync/withdrawals.ts
+++ b/store/zksync/withdrawals.ts
@@ -33,7 +33,7 @@ export const useZkSyncWithdrawalsStore = defineStore("zkSyncWithdrawals", () => 
         providerStore.requestProvider().then((provider) => provider.getTransactionDetails(withdrawal.transactionHash!))
       );
 
-      const withdrawalFinalizationAvailable = !!transactionDetails.ethExecuteTxHash;
+      const withdrawalFinalizationAvailable = transactionDetails.status === "verified";
       const isFinalized = withdrawalFinalizationAvailable
         ? await useZkSyncWalletStore()
             .getL1VoidSigner(true)

--- a/views/transactions/Transfer.vue
+++ b/views/transactions/Transfer.vue
@@ -201,7 +201,7 @@
             target="_blank"
             class="ml-auto text-right"
           >
-            5+ hours
+            6+ hours
           </CommonButtonLabel>
           <CommonButtonLabel v-else-if="type === 'transfer'" as="span" class="ml-auto text-right">
             Almost instant


### PR DESCRIPTION
- remove check for ethExecuteTxHash and use transaction status instead
  - prevents withdrawal from being marked as claimable before it's actually ready
- update hyperchainsexample config to add other params from network.ts
- update withdrawal delay to 6 hours to match current delay