### PR TITLE
fix: prividium rpcUrl

### DIFF
--- a/data/networks.ts
+++ b/data/networks.ts
@@ -170,7 +170,7 @@ const publicChains: ZkSyncNetwork[] = [
     hidden: true,
     key: "prividium-era-testnet",
     name: "Prividium Era Testnet",
-    rpcUrl: "https://proxy.era-prividium.zksync.dev/rpc/public",
+    rpcUrl: "https://proxy.era-prividium.zksync.dev/rpc",
     blockExplorerUrl: "https://block-explorer.era-prividium.zksync.dev",
     // blockExplorerApi: "https://block-explorer-api.sepolia.zksync.dev",
     // l1Network: l1Networks.sepolia,


### PR DESCRIPTION
# What :computer: 
* Update `prividium-era-testnet` `rpcUrl`

# Why :hand:
* It's pointed to the out-dated value

# Evidence :camera:
**BEFORE**             |  **AFTER**
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/a9373bb4-8ee0-4fa6-9597-94cc270c0762)  | ![image](https://github.com/user-attachments/assets/a0250e58-760a-4016-8085-d548fde90a86)