### PR TITLE
fix: handle different ETH address for l1 token

### DIFF
--- a/store/zksync/ethereumBalance.ts
+++ b/store/zksync/ethereumBalance.ts
@@ -24,9 +24,37 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
     if (!ethereumBalance.value) throw new Error("Ethereum balances are not available");
 
     // Get balances from Ankr API and merge them with tokens data from explorer
+    // Special handling: if base token is ETH but has different L1 address than standard ETH,
+    // merge Ankr's standard ETH balance with the base token entry to avoid duplicates
+    const baseETHToken = Object.values(l1Tokens.value ?? []).find((token) => token.isETH);
+    const ankrStandardETH = ethereumBalance.value.find((e) => e.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase());
+    const shouldMergeETH = baseETHToken && ankrStandardETH && baseETHToken.address.toUpperCase() !== ankrStandardETH.address.toUpperCase();
+
+    const tokensNotInAnkr = Object.values(l1Tokens.value ?? [])
+      .filter((token) => {
+        const existsInAnkr = ethereumBalance.value?.find((e) => e.address === token.address);
+        // If this is the base ETH token and we're merging with Ankr's standard ETH, don't add it separately
+        if (shouldMergeETH && token.address === baseETHToken?.address) {
+          return false;
+        }
+        return !existsInAnkr;
+      });
+
     return [
       ...ethereumBalance.value.map((e) => {
         const tokenFromExplorer = l1Tokens.value?.[e.address];
+        // If this is Ankr's standard ETH and we need to merge with base token, use base token's address
+        if (shouldMergeETH && e.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase()) {
+          return {
+            ...e,
+            address: baseETHToken!.address, // Use base token's L1 address
+            symbol: baseETHToken!.symbol,
+            name: baseETHToken!.name,
+            iconUrl: baseETHToken!.iconUrl ?? e.iconUrl,
+            price: tokenFromExplorer?.price ?? e.price,
+            isETH: true,
+          };
+        }
         return {
           ...e,
           symbol: tokenFromExplorer?.symbol ?? e.symbol,
@@ -35,12 +63,10 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
           price: tokenFromExplorer?.price ?? e.price,
         };
       }),
-      ...Object.values(l1Tokens.value ?? []) // Add tokens that are not in Ankr API
-        .filter((token) => !ethereumBalance.value?.find((e) => e.address === token.address))
-        .map((e) => ({
-          ...e,
-          amount: "0",
-        })),
+      ...tokensNotInAnkr.map((e) => ({
+        ...e,
+        amount: "0",
+      })),
     ].sort((a, b) => {
       if (a.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase()) return -1; // Always bring ETH to the beginning
       if (b.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase()) return 1; // Keep ETH at the beginning if comparing with any other token

--- a/store/zksync/ethereumBalance.ts
+++ b/store/zksync/ethereumBalance.ts
@@ -27,18 +27,20 @@ export const useZkSyncEthereumBalanceStore = defineStore("zkSyncEthereumBalances
     // Special handling: if base token is ETH but has different L1 address than standard ETH,
     // merge Ankr's standard ETH balance with the base token entry to avoid duplicates
     const baseETHToken = Object.values(l1Tokens.value ?? []).find((token) => token.isETH);
-    const ankrStandardETH = ethereumBalance.value.find((e) => e.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase());
-    const shouldMergeETH = baseETHToken && ankrStandardETH && baseETHToken.address.toUpperCase() !== ankrStandardETH.address.toUpperCase();
+    const ankrStandardETH = ethereumBalance.value.find(
+      (e) => e.address.toUpperCase() === utils.ETH_ADDRESS.toUpperCase()
+    );
+    const shouldMergeETH =
+      baseETHToken && ankrStandardETH && baseETHToken.address.toUpperCase() !== ankrStandardETH.address.toUpperCase();
 
-    const tokensNotInAnkr = Object.values(l1Tokens.value ?? [])
-      .filter((token) => {
-        const existsInAnkr = ethereumBalance.value?.find((e) => e.address === token.address);
-        // If this is the base ETH token and we're merging with Ankr's standard ETH, don't add it separately
-        if (shouldMergeETH && token.address === baseETHToken?.address) {
-          return false;
-        }
-        return !existsInAnkr;
-      });
+    const tokensNotInAnkr = Object.values(l1Tokens.value ?? []).filter((token) => {
+      const existsInAnkr = ethereumBalance.value?.find((e) => e.address === token.address);
+      // If this is the base ETH token and we're merging with Ankr's standard ETH, don't add it separately
+      if (shouldMergeETH && token.address === baseETHToken?.address) {
+        return false;
+      }
+      return !existsInAnkr;
+    });
 
     return [
       ...ethereumBalance.value.map((e) => {


### PR DESCRIPTION
# What :computer: 
* Handle differing address for L1 base token address and Ankr balance address

# Why :hand:
* Ankr is returning balance of ETH at address `0x00...000` while the L1 base token address for ZKsync OS is actually `0x00...001`

# Evidence :camera:
Successfully bridged funds
<img width="1288" height="615" alt="image" src="https://github.com/user-attachments/assets/656165e7-d38d-460c-9e8a-00c28ac218f0" />
