### PR TITLE
chore: add deployments for zksync-os portal environment

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -7,6 +7,9 @@
       "hosting": {
         "web": [
           "zksync-dapp-wallet-v2"
+        ],
+        "zksync-os": [
+          "zksync-os-dapp-portal"
         ]
       }
     },
@@ -14,6 +17,9 @@
       "hosting": {
         "web": [
           "staging-zksync-dapp-wallet-v2"
+        ],
+        "zksync-os": [
+          "staging-zksync-os-dapp-portal"
         ]
       }
     }

--- a/.github/workflows/zksync-os.yml
+++ b/.github/workflows/zksync-os.yml
@@ -1,0 +1,46 @@
+name: Deploy ZKsync OS
+on:
+  push:
+    branches:
+      - zksyncos-alpha
+
+jobs:
+  deploy:
+    name: Build and Deploy ZKsync OS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci --force
+
+      - name: Setup .env
+        run: |
+          echo "WALLET_CONNECT_PROJECT_ID=${{ secrets.WALLET_CONNECT_PROJECT_ID }}" > .env
+          echo "ANKR_TOKEN=${{ secrets.ANKR_TOKEN }}" >> .env
+          echo "SCREENING_API_URL=${{ secrets.SCREENING_API_URL }}" >> .env
+          echo "DATAPLANE_URL=${{ secrets.DATAPLANE_URL }}" >> .env
+          echo "RUDDER_KEY=${{ secrets.RUDDER_KEY }}" >> .env
+
+      - name: Build
+        run: |
+          npm run generate
+
+      - name: Deploy to ZKsync OS Site
+        uses: matter-labs/action-hosting-deploy@main
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ZKSYNC_DAPP_WALLET_V2 }}"
+          projectId: zksync-dapp-wallet-v2
+          channelId: live
+          target: zksync-os

--- a/.releaserc
+++ b/.releaserc
@@ -11,6 +11,10 @@
     {
       "name": "alpha",
       "prerelease": true
+    },
+    {
+      "name": "zksyncos-alpha",
+      "prerelease": true
     }
   ],
   "plugins": [

--- a/firebase.json
+++ b/firebase.json
@@ -59,6 +59,44 @@
           "type": 301
         }
       ]
+    },
+    {
+      "target": "zksync-os",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**", "**/*.map"],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache, no-store, must-revalidate"
+            },
+            {
+              "key": "Referrer-Policy",
+              "value": "no-referrer, strict-origin-when-cross-origin"
+            },
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "DENY"
+            },
+            {
+              "key": "X-XSS-Protection",
+              "value": "1; mode=block"
+            }
+          ]
+        }
+      ]
     }
   ],
   "emulators": {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -61,6 +61,12 @@ export default defineNuxtConfig({
 
   css: ["@/assets/css/tailwind.css", "@/assets/css/style.scss", "web3-avatar-vue/dist/style.css"],
   ssr: false,
+  nitro: {
+    preset: "static",
+    output: {
+      publicDir: "dist",
+    },
+  },
 
   pinia: {
     storesDirs: ["./store/**"],


### PR DESCRIPTION
# What :computer: 
* Added GitHub Actions workflow for automated ZKsync OS portal deployments
* Configured Firebase hosting targets for ZKsync OS environments (production and staging)
* Added `zksyncos-alpha` branch to semantic release configuration
* Updated Nuxt config to build static output to `dist` directory
* Set up environment variables and secrets handling in deployment workflow

# Why :hand:
* Need automated CI/CD pipeline to deploy the dapp portal to ZKsync OS-specific Firebase hosting targets without manual intervention
* Firebase hosting configuration is required to support multiple deployment targets (web and zksync-os) with separate hosting sites for production and staging
* The `zksyncos-alpha` branch needs to be included in semantic release to enable proper versioning for ZKsync OS alpha releases
* Nuxt static build configuration ensures the build output directory (`dist`) matches what Firebase hosting expects for deployment
* Environment variables in the workflow enable proper configuration of WalletConnect, Ankr, screening API, dataplane, and Rudder analytics for the deployed application

# Evidence :camera:
The workflow file `.github/workflows/zksync-os.yml` includes:
- Trigger on `zksyncos-alpha` branch pushes
- Build steps with dependency installation and static generation
- Environment variable setup from GitHub secrets
- Deployment to Firebase using the `matter-labs/action-hosting-deploy` action targeting the `zksync-os` hosting channel

Firebase configuration in `firebase.json` now includes:
- New `zksync-os` hosting target with security headers and SPA routing
- Proper cache control and security headers (CSP, X-Frame-Options, etc.)

Firebase RC file `.firebaserc` maps:
- `zksync-os` → `zksync-os-dapp-portal` (production)
- `zksync-os` → `staging-zksync-os-dapp-portal` (staging)

# Notes :memo:
* The workflow uses the same Firebase project (`zksync-dapp-wallet-v2`) but deploys to separate hosting targets
* All required secrets must be configured in GitHub repository settings: `WALLET_CONNECT_PROJECT_ID`, `ANKR_TOKEN`, `SCREENING_API_URL`, `DATAPLANE_URL`, `RUDDER_KEY`, and `FIREBASE_SERVICE_ACCOUNT_ZKSYNC_DAPP_WALLET_V2`