### PR TITLE
fix: updating 150% buffer to l2 gas price to prevent MsgValueTooLow errors

### DIFF
--- a/composables/zksync/deposit/useFee.ts
+++ b/composables/zksync/deposit/useFee.ts
@@ -72,7 +72,7 @@ export default (tokens: Ref<Token[]>, balances: Ref<TokenAmount[] | undefined>) 
     };
   };
   const getGasPrice = async () => {
-    return (BigInt(await retry(() => getPublicClient().getGasPrice())) * 130n) / 100n;
+    return (BigInt(await retry(() => getPublicClient().getGasPrice())) * 150n) / 100n;
   };
   const {
     inProgress,


### PR DESCRIPTION
Deposits on zero-network were failing due to MsgValueTooLow. Bumping the L2 gas price buffer further was required