### PR TITLE
fix: broadcast L2 transactions through the ZKsync RPC

### DIFF
--- a/store/zksync/wallet.ts
+++ b/store/zksync/wallet.ts
@@ -1,8 +1,9 @@
 import { ethers } from "ethers";
 import { $fetch } from "ofetch";
-import { L1Signer, L1VoidSigner, BrowserProvider, Signer } from "zksync-ethers";
+import { L1Signer, L1VoidSigner, Signer } from "zksync-ethers";
 
 import { customBridgeTokens } from "@/data/customBridgeTokens";
+import { EraBrowserProvider } from "@/utils/era-browser-provider";
 import { getBalancesWithCustomBridgeTokens, AddressChainType } from "@/utils/helpers";
 
 import type { Api, TokenAmount } from "@/types";
@@ -25,13 +26,14 @@ export const useZkSyncWalletStore = defineStore("zkSyncWallet", () => {
       );
     }
 
-    const web3Provider = new BrowserProvider((await onboardStore.getWallet(eraNetwork.value.id)) as any, "any");
-    const rawEthersSigner = await web3Provider.getSigner();
-    const eraL2Signer = Signer.from(
-      rawEthersSigner,
-      Number(eraNetwork.value.id),
-      await providerStore.requestProvider()
+    const l2Provider = await providerStore.requestProvider();
+    const web3Provider = new EraBrowserProvider(
+      (await onboardStore.getWallet(eraNetwork.value.id)) as any,
+      "any",
+      l2Provider
     );
+    const rawEthersSigner = await web3Provider.getSigner();
+    const eraL2Signer = Signer.from(rawEthersSigner, Number(eraNetwork.value.id), l2Provider);
 
     return eraL2Signer;
   });

--- a/utils/era-browser-provider.ts
+++ b/utils/era-browser-provider.ts
@@ -1,0 +1,22 @@
+import { BrowserProvider } from "zksync-ethers";
+
+import type { Eip1193Provider, Networkish } from "ethers";
+import type { Provider } from "zksync-ethers";
+
+/**
+ * zksync-ethers broadcasts EIP-712 (type 113) transactions through the signer's browser provider,
+ * not the L2 provider passed to `Signer.from`. Wallet RPCs can't decode type 113 — MetaMask defaults
+ * ZKsync Era to Infura since 13.36.0 (MetaMask/metamask-extension#43407) — so redirect broadcasts.
+ */
+export class EraBrowserProvider extends BrowserProvider {
+  private readonly l2Provider: Provider;
+
+  constructor(ethereum: Eip1193Provider, network: Networkish | undefined, l2Provider: Provider) {
+    super(ethereum, network);
+    this.l2Provider = l2Provider;
+  }
+
+  override broadcastTransaction(signedTx: string) {
+    return this.l2Provider.broadcastTransaction(signedTx);
+  }
+}


### PR DESCRIPTION
## Problem

Every L2 transfer and withdrawal on portal.zksync.io fails immediately after the user confirms the signature:

```json
{
  "code": -32602,
  "message": "Invalid parameters: transaction could not be decoded: unsupported transaction type",
  "cause": null
}
```

Nothing changed in the portal — the break is in MetaMask.

## Root cause

`zksync-ethers` signs the EIP-712 (type 113) transaction with the wallet and then broadcasts it through **the signer's browser provider**, not the L2 provider we hand to `Signer.from`:

```js
// zksync-ethers/build/signer.js:581-582
const txBytes = serializeEip712(zkTx);
return await this.provider.broadcastTransaction(txBytes);   // this.provider === BrowserProvider
```

`providerL2` is only consulted for `zks_*` calls — the SDK even comments that MetaMask does not forward those, but leaves broadcasting on the wallet anyway. So the raw type-0x71 bytes go to whatever RPC the wallet is pointed at.

[MetaMask/metamask-extension#43407](https://github.com/MetaMask/metamask-extension/pull/43407) ("migrate zkSync Era default RPC to Infura"), shipped in **MetaMask 13.36.0 on 2026-06-20**, switched that RPC from `mainnet.era.zksync.io` to `https://zksync-mainnet.infura.io/v3/…` — including migration 213, which rewrote already-installed profiles. That endpoint cannot decode type 113.

The Era sequencer itself is fine and still accepts type 113; its rejection wording for a genuinely unknown type is different (`code 3, "Failed to serialize transaction: transaction type is not supported"`), which is how the wallet RPC was identified as the source.

## Fix

`EraBrowserProvider` overrides `broadcastTransaction` to send through the network's own RPC. Signing, nonces and gas estimation still go through the wallet, so the confirmation UX is unchanged.

This also makes the portal independent of whatever RPC each user's wallet is configured with, rather than only unbreaking today's MetaMask default — worth having regardless of the pending [QuickNode failover for ZKsync Era](https://github.com/MetaMask/metamask-extension/pull/45141), which would otherwise add a second non-Era endpoint to the path.

The Prividium path already signs and broadcasts separately and is unaffected. L1 signers are untouched — those are standard transaction types that wallet RPCs handle.

One behaviour change worth knowing: MetaMask no longer sees the transaction, so it will not appear in its activity list. That already matches how the Prividium path behaves.

## Verification

Harness driving the real `Signer.sendTransaction` against a mock EIP-1193 wallet that records every method it is asked to perform:

```
--- Case A: plain BrowserProvider (main)
  wallet methods used : eth_chainId, eth_accounts, eth_getTransactionCount, eth_signTypedData_v4, eth_blockNumber, eth_sendRawTransaction
  raw tx -> Era RPC   : no
  error               : WALLET RECEIVED RAW TX (this is the bug): 0x71f89081a0...

--- Case B: EraBrowserProvider (fix)
  wallet methods used : eth_chainId, eth_accounts, eth_getTransactionCount, eth_signTypedData_v4
  raw tx -> Era RPC   : yes (type 0x71)
  error               : none
```

Replaying the exact bytes Case B produces against `https://mainnet.era.zksync.io`:

```
{"code":3,"message":"nonce too high. allowed nonce range: 0 - 40, actual: 160"}
```

Decoding, RLP and signature recovery all pass — it fails only on the throwaway signer's nonce, which is expected.

`npm run lint` passes. `tsc --noEmit` reports the same 10 pre-existing errors as `main`, none in the changed files.

## Manual testing steps

1. MetaMask 13.36.0 or later, ZKsync Era selected — confirm the network's RPC URL is `zksync-mainnet.infura.io`.
2. On `main`, send an ETH transfer: fails after signing with the error above.
3. On this branch, repeat: transfer is submitted and confirms.
4. Repeat for a withdrawal, and for an ERC-20 transfer.
5. Point MetaMask's ZKsync Era RPC back at `https://mainnet.era.zksync.io` and confirm both still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
