### PR TITLE
fix: build Docker image on Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine AS base-stage
+FROM node:20-alpine AS base-stage
 
 WORKDIR /usr/src/app
 COPY package*.json ./


### PR DESCRIPTION
## Problem

The `Build Docker` job has failed on every release since [#293 (Nov 2025)](https://github.com/matter-labs/dapp-portal/actions/runs/19042940650), most recently on [#303](https://github.com/matter-labs/dapp-portal/actions/runs/30839751696/job/91774453242):

```
buildx failed: process "/bin/sh -c npm cache clean --force && npm install" did not complete successfully: exit code: 1
```

The install itself is fine — the `postinstall` hook is what dies:

```
> nuxt prepare
ERROR  Cannot find native binding. npm has a bug related to optional dependencies (npm/cli#4828).
       Please try npm i again after removing both package-lock.json and node_modules directory.
[cause]: Cannot find module '@oxc-parser/binding-linux-x64-musl'
```

## Root cause

npm's hint is a red herring — the binding is in the lockfile. It is skipped because its `engines` cannot be satisfied:

```jsonc
"node_modules/@oxc-parser/binding-linux-x64-musl": {
  "optional": true,
  "engines": { "node": "^20.19.0 || >=22.12.0" }
}
```

The image is built on `node:18.17.1-alpine`. npm silently skips optional dependencies whose `engines` don't match, so the native binding never lands and `nuxt prepare` cannot load it.

Node 18 also contradicts what the project already declares — `package.json` requires `>=20.0.0`, and Nuxt 3.19.3 requires `^20.19.0 || >=22.12.0`. Every workflow uses `node-version: '20'`, which is why `Publish` and `Deploy to Staging` pass and only the container build fails.

## Fix

Bump the base image to `node:20-alpine`, matching the version CI already uses. Nothing else changes; `package-lock.json` is untouched.

`node:22-alpine` would move to current LTS, but that diverges from the workflows — better to bump both together in a separate change.

## Verification

Built the install layer against `linux/amd64` with this repo's unmodified `package.json` and `package-lock.json`:

```
node v20.20.2
node_modules/@oxc-parser/binding-linux-x64-musl   ← installed (skipped on Node 18)
.nuxt generated by postinstall: yes               ← nuxt prepare completed
```

`npm cache clean --force && npm install` exits 0 — the exact step that fails today.

Scope of that check: the install layer only, not the subsequent `npm run generate`. A full Nuxt build on Node 20 is already exercised by the `Publish` job, so the remaining risk is low, but this PR's own `Build Docker` run is the real end-to-end proof — worth confirming it goes green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
